### PR TITLE
fixed numpy128 issue for windows

### DIFF
--- a/howfsc/util/constrain_dm.py
+++ b/howfsc/util/constrain_dm.py
@@ -195,7 +195,7 @@ def tie_with_matrix(volts, tie):
         else:
             # Grab mean value of all actuators that are tied together
             # upcast to f128 for greater bit width (see PFR 218113)
-            mean_val = np.mean(dmtied[tie == tienum], dtype=np.float128)
+            mean_val = np.mean(dmtied[tie == tienum], dtype=np.longdouble)
             # Assign indices in DM mask to mean value, back as f64
             dmtied[tie == tienum] = mean_val.astype(np.float64)
             continue


### PR DESCRIPTION
`np.float128` does not exist in numpy for windows, changed this to `np.longdouble` which gives you the best precision available on your platform. 

- [x] Tested on windows
- [x] Tested on mac/linux