### PR TITLE
Use single-actuator probes in HOWFSC loop

### DIFF
--- a/howfsc/model/testdata/narrowfov/narrowfov_dmrel_1.0e-05_act0.fits
+++ b/howfsc/model/testdata/narrowfov/narrowfov_dmrel_1.0e-05_act0.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fc9328f7e5db2dde82d85b080e4e9311e46d75a33baf6e5a5520283358648a0
+size 23040

--- a/howfsc/model/testdata/narrowfov/narrowfov_dmrel_1.0e-05_act1.fits
+++ b/howfsc/model/testdata/narrowfov/narrowfov_dmrel_1.0e-05_act1.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:819186b76794924adc448577d24d73d8d83c53246300e95537164fa474cf1075
+size 23040

--- a/howfsc/model/testdata/narrowfov/narrowfov_dmrel_1.0e-05_act2.fits
+++ b/howfsc/model/testdata/narrowfov/narrowfov_dmrel_1.0e-05_act2.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a65373ff4b3da6fbe8fda5cd99ee32f24e29f7f908fd7d49d59c44eb9cc65b0f
+size 23040

--- a/howfsc/scripts/nulltest_gitl.py
+++ b/howfsc/scripts/nulltest_gitl.py
@@ -184,11 +184,11 @@ def nulling_test_gitl(niter=5, mode='narrowfov', isprof=False, logfile=None, fra
         jacfile = os.path.join(jacpath, 'narrowfov_jac_full.fits')
         cstratfile = os.path.join(modelpath, 'cstrat_narrowfov.yaml')
         probe0file = os.path.join(modelpath,
-                                  'narrowfov_dmrel_1.0e-05_cos.fits')
+                                  'narrowfov_dmrel_1.0e-05_act0.fits')
         probe1file = os.path.join(modelpath,
-                                  'narrowfov_dmrel_1.0e-05_sinlr.fits')
+                                  'narrowfov_dmrel_1.0e-05_act1.fits')
         probe2file = os.path.join(modelpath,
-                                  'narrowfov_dmrel_1.0e-05_sinud.fits')
+                                  'narrowfov_dmrel_1.0e-05_act2.fits')
         hconffile = os.path.join(modelpath, 'hconf_narrowfov.yaml')
         n2clistfiles = [
             os.path.join(modelpath, 'narrowfov_n2c_idx0.fits'),


### PR DESCRIPTION
> [!IMPORTANT]  
> This is a DRAFT pull request that illustrates a fast implementation of a new feature. It needs to be reworked to fold into the ongoing work of the HOWFSC ground-software task force in the CPP hardware working group.

This PR shows how to use alternate probes inside the default HOWFSC loop. The loop runs successfully with these files and code, although the exact control strategy needs to be adjusted and quantitatively evaluated.

### Todo:
- [ ] Adjustment of the single-actuator probe files: scale their amplitude inside the files such that when applied on the DM, the relative added mean intensity in the DH is 1e-5 of the unprobed stellar PSF peak. This is how the standard sinc-sinc-sine probe files are scaled, so we want the same for any alternate probes.
- [ ] Change the code so that the probe files can be chosen as inputs instead of hacking a hard-coded change into the code like done here. There is an ongoing effort for this capability on https://github.com/roman-corgi/corgihowfsc, so there needs to be some coordination about which code gets changed and added in which of these two repositories.